### PR TITLE
Add save poster function and saved posters grid query selector

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,9 +1,8 @@
 ## Feature Description
 >Clearly and concisely describe the feature.
 
-Takes input from image URL, title and quote to create and show as a new motivational poster.
-As it accomplishes this it also toggles back to the main page to show the poster and prevents the default random poster to be shown.
-Also cleaned up some code and added necessary semicolons.
+Add save poster function.
+Add saved posters grid query selector.
 
 ## Analysis and Design
 >Analyze and attach the design documentation, if any.
@@ -13,11 +12,9 @@ N/A
 ## Solution Description
 >Describe your code changes in detail for reviewers.
 
-Added a couple new functions.
-The generatePoster function establishes through innerText the input values to the input boxes on the webpage.
-It then passes them through into the Poster class.
-Then by calling the showMyPoster the generatePoster function, event.preventDefault function and
-hideForm function are all called initiating the input values to be formed as a customized poster.
+Uses the ! operator to scan and make sure that there are going to be no repeating saved posters to the saved posters page.
+
+Also created a savedPostersGrid query selector.
 
 ## Output screenshots
 >Post the output screenshots, if an UI is affected or added due to this feature.

--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,7 @@ var backToMainButton = document.querySelector('.back-to-main');
 
 // saved posters page
 var savedPostersForm = document.querySelector('.saved-posters');
-
+var savedPostersGrid = document.querySelector('.saved-posters-grid');
 
 // we've provided you with some data to work with 👇
 var images = [
@@ -159,10 +159,6 @@ function showPoster() {
   posterQuote.innerText = currentPoster.quote;
 };
 
-function savePoster() {
-  savedPosters.push(currentPoster);
-};
-
 //functions on create your own poster page
 function openForm() {
   mainPosterPage.classList.toggle('hidden');
@@ -198,3 +194,9 @@ function hideSavedPostersForm() { 
   savedPostersForm.classList.toggle('hidden'); 
   mainPosterPage.classList.toggle('hidden'); 
 } ;
+
+function savePoster() {
+  if (!savedPosters.includes(currentPoster)){
+  savedPostersGrid.push(currentPoster);
+  }
+};


### PR DESCRIPTION
## Feature Description
>Clearly and concisely describe the feature.

Takes input from image URL, title and quote to create and show as a new motivational poster.
As it accomplishes this it also toggles back to the main page to show the poster and prevents the default random poster to be shown.
Also cleaned up some code and added necessary semicolons.

## Analysis and Design
>Analyze and attach the design documentation, if any.

N/A

## Solution Description
>Describe your code changes in detail for reviewers.

Added a couple new functions.
The generatePoster function establishes through innerText the input values to the input boxes on the webpage.
It then passes them through into the Poster class.
Then by calling the showMyPoster the generatePoster function, event.preventDefault function and
hideForm function are all called initiating the input values to be formed as a customized poster.

## Output screenshots
>Post the output screenshots, if an UI is affected or added due to this feature.

N/A
