### PR TITLE
Add all saved posters to grid

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,7 +1,7 @@
 ## Feature Description
 >Clearly and concisely describe the feature.
 
-Refactored innerHTML in order to get saved posters to show up, but still having problems getting more than one mini-poster to show up.
+Refactored innerHTML in order to get saved posters to show up. Show saved posters button now shows all of the saved posters.
 
 ## Analysis and Design
 >Analyze and attach the design documentation, if any.
@@ -12,6 +12,7 @@ N/A
 >Describe your code changes in detail for reviewers.
 
 Used innerHTML to insert same structure of main poster into the poster grid to allow for mini poster to appear.
+By assigning savedPostersGrid to an empty string and using += operator to add each innerHTML insertion, we were able to get all the saved posters to show up.
 
 ## Output screenshots
 >Post the output screenshots, if an UI is affected or added due to this feature.

--- a/src/main.js
+++ b/src/main.js
@@ -205,10 +205,10 @@ function savePoster() {
 };
 
 function displayOnGrid() {
-
   openSavedPostersForm();
+  savedPostersGrid.innerHTML = '';
   for (var i = 0; i < savedPosters.length; i++) {
-     savedPostersGrid.innerHTML = `
+     savedPostersGrid.innerHTML += `
      <article class="mini-poster">
       <img class="mini-poster" src="${savedPosters[i].imageURL}" alt="Saved Poster">
       <h2>${savedPosters[i].title}</h2>


### PR DESCRIPTION
## Feature Description
>Clearly and concisely describe the feature.

Now all the saved posters will appear in the saved poster grid.

## Analysis and Design
>Analyze and attach the design documentation, if any.

N/A

## Solution Description
>Describe your code changes in detail for reviewers.

Used innerHTML to insert same structure of main poster into the poster grid to allow for mini poster to appear. Then made savedPostersGrid a string and used the += operator to add multiple string of the HTML into the grid allowing for multiple mini-posters.

## Output screenshots
>Post the output screenshots, if an UI is affected or added due to this feature.

N/A
